### PR TITLE
Added Support for user specificed CA file and url encoding of JMX pat…

### DIFF
--- a/beater/data.go
+++ b/beater/data.go
@@ -10,15 +10,16 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
 const (
-	managerJmxproxy = "/manager/jmxproxy/?get="
-	attributeURI    = "&att="
-	keyURI          = "&key="
+	managerJmxproxy = "/manager/jmxproxy/"
 )
 
 func (bt *Jmxproxybeat) GetJMX(u url.URL) error {
@@ -26,40 +27,27 @@ func (bt *Jmxproxybeat) GetJMX(u url.URL) error {
 		for j := 0; j < len(bt.Beans[i].Attributes); j++ {
 			if len(bt.Beans[i].Attributes[j].Keys) > 0 {
 				for k := 0; k < len(bt.Beans[i].Attributes[j].Keys); k++ {
-					logp.Debug(selector, "Host: %s, request: %s", u.String(), bt.Beans[i].Name+
-						attributeURI+bt.Beans[i].Attributes[j].Name+
-						keyURI+bt.Beans[i].Attributes[j].Keys[k])
 
-					err := bt.GetJMXObject(u, bt.Beans[i].Name, bt.Beans[i].Attributes[j].Name, bt.Beans[i].Attributes[j].Keys[k])
+					err := bt.GetJMXObject(u, bt.Beans[i].Name, bt.Beans[i].Attributes[j].Name, bt.Beans[i].Attributes[j].Keys[k], bt.CAFile)
 					if err != nil {
-						logp.Err("Error requesting JMX for %s: %v", bt.Beans[i].Name+
-							attributeURI+bt.Beans[i].Attributes[j].Name+
-							keyURI+bt.Beans[i].Attributes[j].Keys[k], err)
+						logp.Err("Error requesting JMX: %v", err)
 					}
 				}
 			} else {
 				if len(bt.Beans[i].Keys) > 0 {
 					for k := 0; k < len(bt.Beans[i].Keys); k++ {
-						logp.Debug(selector, "Host: %s, request: %s", u.String(), bt.Beans[i].Name+
-							attributeURI+bt.Beans[i].Attributes[j].Name+
-							keyURI+bt.Beans[i].Keys[k])
 
-						err := bt.GetJMXObject(u, bt.Beans[i].Name, bt.Beans[i].Attributes[j].Name, bt.Beans[i].Keys[k])
+						err := bt.GetJMXObject(u, bt.Beans[i].Name, bt.Beans[i].Attributes[j].Name, bt.Beans[i].Keys[k], bt.CAFile)
 						if err != nil {
-							logp.Err("Error requesting JMX for %s: %v", bt.Beans[i].Name+
-								attributeURI+bt.Beans[i].Attributes[j].Name+
-								keyURI+bt.Beans[i].Keys[k], err)
+							logp.Err("Error requesting JMX: %v", err)
 						}
 					}
 
 				} else {
-					logp.Debug(selector, "Host: %s, request: %s", u.String(), bt.Beans[i].Name+
-						attributeURI+bt.Beans[i].Attributes[j].Name)
 
-					err := bt.GetJMXObject(u, bt.Beans[i].Name, bt.Beans[i].Attributes[j].Name, "")
+					err := bt.GetJMXObject(u, bt.Beans[i].Name, bt.Beans[i].Attributes[j].Name, "", bt.CAFile)
 					if err != nil {
-						logp.Err("Error requesting JMX for %s: %v", bt.Beans[i].Name+
-							attributeURI+bt.Beans[i].Attributes[j].Name, err)
+						logp.Err("Error requesting JMX: %v", err)
 					}
 				}
 			}
@@ -68,18 +56,58 @@ func (bt *Jmxproxybeat) GetJMX(u url.URL) error {
 	return nil
 }
 
-func (bt *Jmxproxybeat) GetJMXObject(u url.URL, name, attribute, key string) error {
-	client := &http.Client{}
-	var jmxObject, jmxAttribute string
+func (bt *Jmxproxybeat) GetJMXObject(u url.URL, name, attribute, key string, CAFile string) error {
+
+	tlsConfig := &tls.Config{RootCAs: x509.NewCertPool()}
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+    var ParsedUrl *url.URL
+
+    if CAFile != "" {
+		// Load our trusted certificate path
+		pemData, err := ioutil.ReadFile(CAFile)
+		if err != nil {
+			panic(err)
+		}
+		ok := tlsConfig.RootCAs.AppendCertsFromPEM(pemData)
+		if !ok {
+		    logp.Err("Unable to load CA file")
+			panic("Couldn't load PEM data")
+		}
+    }
+
+	//client := &http.Client{}
+	client := &http.Client{Transport: transport}
+
+	ParsedUrl, err := url.Parse(u.String())
+    if err != nil {
+		logp.Err("Unable to parse URL String")
+		panic(err)
+    }
+
+    ParsedUrl.Path += managerJmxproxy
+    parameters := url.Values{}
+
+	parameters.Add("get", name)
+
+	//var jmxObject, 
+    var jmxAttribute string
 	if key != "" {
-		jmxObject = name + attributeURI + attribute + keyURI + key
+		//jmxObject = name + attributeURI + attribute + keyURI + key
+		parameters.Add("att", attribute)
+		parameters.Add("key", key)
 		jmxAttribute = attribute + "." + key
 	} else {
-		jmxObject = name + attributeURI + attribute
+		//jmxObject = name + attributeURI + attribute
+		parameters.Add("att", attribute)
 		jmxAttribute = attribute
 	}
 
-	req, err := http.NewRequest("GET", u.String()+managerJmxproxy+jmxObject, nil)
+
+	ParsedUrl.RawQuery = parameters.Encode()
+
+	logp.Debug(selector, "Requesting JMX: %s", ParsedUrl.String())  
+
+	req, err := http.NewRequest("GET", ParsedUrl.String(), nil)
 
 	if bt.auth {
 		req.SetBasicAuth(bt.username, bt.password)

--- a/beater/jmxproxybeat.go
+++ b/beater/jmxproxybeat.go
@@ -9,7 +9,7 @@ import (
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher"
-	"github.com/radoondas/jmxproxybeat/config"
+	"github.com/ninjasftw/jmxproxybeat/config"
 )
 
 const selector = "jmxproxybeat"
@@ -22,6 +22,7 @@ type Jmxproxybeat struct {
 	auth       bool
 	username   string
 	password   string
+    CAFile     string
 	Beans      []Bean
 	events     publisher.Client
 }
@@ -84,6 +85,15 @@ func (bt *Jmxproxybeat) Setup(b *beat.Beat) error {
 		}
 		bt.urls[i] = u
 	}
+
+
+    if bt.beatConfig.Jmxproxybeat.Ssl.Cafile != "" {
+        logp.Info("CAFile IS set.")
+        bt.CAFile = bt.beatConfig.Jmxproxybeat.Ssl.Cafile
+    } else {
+        logp.Info("CAFile IS NOT set.")
+    }
+    
 
 	if bt.beatConfig.Jmxproxybeat.Authentication.Username == "" || bt.beatConfig.Jmxproxybeat.Authentication.Password == "" {
 		logp.Err("Username or password IS NOT set.")

--- a/beater/jmxproxybeat.go
+++ b/beater/jmxproxybeat.go
@@ -9,7 +9,7 @@ import (
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/publisher"
-	"github.com/ninjasftw/jmxproxybeat/config"
+	"github.com/radoondas/jmxproxybeat/config"
 )
 
 const selector = "jmxproxybeat"

--- a/config/config.go
+++ b/config/config.go
@@ -8,10 +8,15 @@ type Config struct {
 }
 
 type JmxproxybeatConfig struct {
+	Ssl            SSLConfig            `yaml:"ssl"`
 	Period         string               `yaml:"period"`
 	URLs           []string             `yaml:"urls"`
 	Authentication AuthenticationConfig `yaml:"authentication"`
 	Beans          []BeanConfig         `yaml:"beans"`
+}
+
+type SSLConfig struct {
+    Cafile string
 }
 
 type AuthenticationConfig struct {

--- a/jmxproxybeat.yml
+++ b/jmxproxybeat.yml
@@ -13,6 +13,9 @@ jmxproxybeat:
     username: "tomcat"
     password: "s3cret"
 
+  #ssl:
+    #cafile: "/path/to/ca/CA.pem"
+
   beans:
     - bean:
       name: java.lang:type=Memory

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 
-	"github.com/ninjasftw/jmxproxybeat/beater"
+	"github.com/ninjasftw/radoondas/beater"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 
-	"github.com/ninjasftw/radoondas/beater"
+	"github.com/radoondas/jmxproxybeat/beater"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 
-	"github.com/radoondas/jmxproxybeat/beater"
+	"github.com/ninjasftw/jmxproxybeat/beater"
 )
 
 func main() {


### PR DESCRIPTION
I'm using this plugin to monitor a number of tomcat instances.  
There were a couple of issues for my use case that I've fixes and would like to push back into your project.  
*  All our jmx interfaces are ssl protected by custom signed certificates so I needed a way to provide a CA location 
*  I've added url encoding to the JMX urls so that beans such as java.lang:type=GarbageCollector,name=PS Scavenge work natively without needing to encode the whitespace